### PR TITLE
Fix wrong angle when min is not-zero

### DIFF
--- a/src/circle-progress.js
+++ b/src/circle-progress.js
@@ -290,7 +290,7 @@ class CircleProgress {
 		let angle;
 		if(this._isIndeterminate()) return 0;
 		if(this.max === 0) return this.value ? 360 : 0;
-		angle = (this.value - this.min) / this.max * 360;
+		angle = (this.value - this.min) / (this.max - this.min) * 360;
 		angle = Math.min(360, Math.max(0, angle));
 		return angle;
 	}


### PR DESCRIPTION
Fixes the problem whereby when min is non-zero the angle is incorrect. e.g. if min=50 and max=100, the value 50 will correctly be at 0-degrees but 100 will be at 180-degrees, when it should be 360-degrees.